### PR TITLE
Updating switchtool script path for upcoming change

### DIFF
--- a/pcds_shortcuts.sh
+++ b/pcds_shortcuts.sh
@@ -549,7 +549,7 @@ function gw()
 export gw
 function switchtool()
 {
-  /cds/group/pcds/pyps/apps/switchtool/latest/switchtool "$@"
+  /cds/group/pcds/pyps/apps/switchtool/latest/scripts/switchtool "$@"
 }
 export switchtool
 


### PR DESCRIPTION
The top-level switchtool symlink will be removed in https://github.com/pcdshub/switchtool/pull/7 because the module is being renamed from psnet to switchtool so the name switchtool is taken there. Instead this function will access the script itself instead of a link to it. 