### PR TITLE
FIX: use rocky9-compatible script location

### DIFF
--- a/pcds_shortcuts.sh
+++ b/pcds_shortcuts.sh
@@ -198,7 +198,7 @@ function find_pv( )
 			fi
 
 			# Look for IocManager Configs
-			${PYPS_SITE_TOP}/apps/ioc/latest/find_ioc --name $ioc
+			${PYPS_SITE_TOP}/apps/ioc/latest-R3/scripts/find_ioc --name $ioc
 		done
 	done
 }


### PR DESCRIPTION
Fix an issue where find_pv doesn't work on rocky9

Before:
```
zlentz@psbuild-rocky9-01:~/github/epics-setup(fix_rocky9_find_pv -)$ find_pv CXI:DG3:MMS:06
PV: CXI:DG3:MMS:06
        IOC:            ioc-cxi-dg3-newall-le
        IOC_PV:         IOC:CXI:DG3:NEWALL:LE
PSPKG Error: Release /reg/g/pcds/pkg_mgr/release/controls-0.0.1/x86_64-rhel9-gcc114-opt not found!
/usr/bin/env: ‘python’: No such file or directory
        IOC:            ioc-cxi-dg3-stand-ims
        IOC_PV:         IOC:CXI:DG3:STAND:IMS
PSPKG Error: Release /reg/g/pcds/pkg_mgr/release/controls-0.0.1/x86_64-rhel9-gcc114-opt not found!
/usr/bin/env: ‘python’: No such file or directory
        IOC:            ioc-cxi-dg3-stand-le
        IOC_PV:         CXI:R51:IOC:37:DG3:SLE
PSPKG Error: Release /reg/g/pcds/pkg_mgr/release/controls-0.0.1/x86_64-rhel9-gcc114-opt not found!
/usr/bin/env: ‘python’: No such file or directory
```

After:
```
zlentz@psbuild-rocky9-01:~/github/epics-setup(fix_rocky9_find_pv -)$ source ./pcds_shortcuts.sh
zlentz@psbuild-rocky9-01:~/github/epics-setup(fix_rocky9_find_pv -)$ find_pv CXI:DG3:MMS:06
PV: CXI:DG3:MMS:06
        IOC:            ioc-cxi-dg3-newall-le
        IOC_PV:         IOC:CXI:DG3:NEWALL:LE
        CONFIG:         /reg/g/pcds/pyps/config/cxi/iocmanager.cfg
        ALIAS:          Beamline DG3 Newall Stand LE
        DIR:            ioc/cxi/newall-le/R0.0.1
        CMD:
        HOST:           ioc-cxi-usrmot2
        PORT:           39101
        ENABLED:        True
        IOC:            ioc-cxi-dg3-stand-ims
        IOC_PV:         IOC:CXI:DG3:STAND:IMS
        CONFIG:         /reg/g/pcds/pyps/config/cxi/iocmanager.cfg
        ALIAS:          IMS DG3 Stand
        DIR:            ioc/cxi/ims/R6.7.1
        CMD:
        HOST:           ioc-cxi-mot2
        PORT:           30525
        ENABLED:        True
        IOC:            ioc-cxi-dg3-stand-le
        IOC_PV:         CXI:R51:IOC:37:DG3:SLE
```